### PR TITLE
SEARCH-5964 Use GET instead of HEAD when testing the datasource

### DIFF
--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -206,14 +206,14 @@ export class CriblDataSource extends DataSourceApi<CriblQuery, CriblDataSourceOp
   /**
    * Test the datasource, given its current configuration.  A successful test entails:
    * 1. Get an auth token.
-   * 2. Hit the API with a simple HEAD request, ensuring the config & auth token are both valid.
+   * 2. Hit the API with a simple GET request, ensuring the config & auth token are both valid.
    * @returns an object with status and message
    */
   async testDatasource(): Promise<{ status: string, message: string }> {
     try {
       const authorization = await this.getAuthorization();
       await lastValueFrom(getBackendSrv().fetch<any>({
-        method: 'HEAD',
+        method: 'GET',
         url: this.proxiedUrl('testDatasource'),
         headers: { ...authorization },
       }));

--- a/src/plugin.json
+++ b/src/plugin.json
@@ -81,7 +81,6 @@
     },
     {
       "path": "testDatasource",
-      "method": "HEAD",
       "url": "{{ .JsonData.criblOrgBaseUrl }}/api/v1/m/default_search/search/saved"
     },
     {


### PR DESCRIPTION
It's been a while since this was originally written.  Since then, we've introduced AuthZ and policies.yml and the like.  `HEAD` is no longer permitted.  We can use `GET` on the datasource test.  It's less ideal since we don't care about the actual response payload, but that's a small price to pay.

With this change, we're back in business.  Everything seems to be working as expected.