### PR TITLE
SEARCH-6025 Load saved searches, allow user to select easily

### DIFF
--- a/src/components/QueryEditor.tsx
+++ b/src/components/QueryEditor.tsx
@@ -29,13 +29,16 @@ export function QueryEditor({ datasource, query, onChange, onRunQuery }: Props) 
   // Load the saved search IDs, let the user just pick one
   useEffect(() => {
     const loadSavedSearchIds = async () => {
-      const savedSearchIds = await datasource.loadSavedSearchIds();
-      const defaultOption = { label: '', value: '' };
-      const options = [
-        defaultOption,
-        ...savedSearchIds.map((value) => ({ value, label: value })),
-      ];
-      setSavedSearchIdOptions(options);
+      try {
+        const savedSearchIds = await datasource.loadSavedSearchIds();
+        const options = [
+          { label: '', value: '' },
+          ...savedSearchIds.map((value) => ({ value, label: value })),
+        ];
+        setSavedSearchIdOptions(options);
+      } catch (err) {
+        console.log(`Failed to load saved search IDs: ${err}`);
+      }
     };
     loadSavedSearchIds();
   }, [datasource]);

--- a/src/plugin.json
+++ b/src/plugin.json
@@ -80,7 +80,7 @@
       }
     },
     {
-      "path": "testDatasource",
+      "path": "savedSearches",
       "url": "{{ .JsonData.criblOrgBaseUrl }}/api/v1/m/default_search/search/saved"
     },
     {

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,7 +8,7 @@ export interface CriblQuery extends DataQuery {
   /**
    * ID of the Cribl saved search
    */
-  savedQueryId: string;
+  savedSearchId: string;
   /**
    * Max number of results to fetch
    */


### PR DESCRIPTION
No more typing.  Way easier.  Now, whatever saved searches you have available to you...
<img width="1840" alt="Screenshot 2024-05-08 at 4 03 08 PM" src="https://github.com/criblio/cribl-search-grafana-plugin/assets/281311/43d5d6a9-b867-49c3-9c48-7cc0e4c5fbe4">
...are made available to you in Grafana:
<img width="1728" alt="Screenshot 2024-05-08 at 4 02 54 PM" src="https://github.com/criblio/cribl-search-grafana-plugin/assets/281311/a393f453-df02-4015-bcf3-6efec3eeec30">

You simply pick from the dropdown.

Other Notes:
- I renamed the `testDatasource` route (in `plugin.json`) to `savedSearches`, since that's not only used by `testDatasource()` but also by `loadSavedSearchIds()`.