### PR TITLE
SEARCH-6105 Remove "Max Results" control & impose fixed 10k limit

### DIFF
--- a/src/components/QueryEditor.tsx
+++ b/src/components/QueryEditor.tsx
@@ -10,8 +10,6 @@ type Props = QueryEditorProps<CriblDataSource, CriblQuery, CriblDataSourceOption
 const queryTypeOptions = ['saved', 'adhoc'].map((value) => ({ label: value, value }));
 
 export function QueryEditor({ datasource, query, onChange, onRunQuery }: Props) {
-  const { maxResults } = query;
-
   const debouncedOnRunQuery = useRef(debounce(onRunQuery, 750)).current;
   const [savedSearchIdOptions, setSavedSearchIdOptions] = useState<SelectableValue[]>([]);
   const [savedSearchId, setSavedSearchId] = useState('');
@@ -51,11 +49,6 @@ export function QueryEditor({ datasource, query, onChange, onRunQuery }: Props) 
     }
   };
 
-  const onMaxResultsChange = (event: ChangeEvent<HTMLInputElement>) => {
-    onChange({ ...query, maxResults: Math.max(1, +event.target.value) });
-    debouncedOnRunQuery();
-  };
-
   // Load the saved search IDs, let the user just pick one
   useEffect(() => {
     const loadSavedSearchIds = async () => {
@@ -87,9 +80,6 @@ export function QueryEditor({ datasource, query, onChange, onRunQuery }: Props) 
         <Select onChange={onQueryTypeChange} options={queryTypeOptions} value={queryType} width={12} />
       </InlineField>
       {getQueryUI()}
-      <InlineField label="Max Results" labelWidth={16} tooltip="Max results to fetch">
-        <Input onChange={onMaxResultsChange} value={maxResults ?? 1000} width={24} type="number" />
-      </InlineField>
     </div>
   );
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,12 +4,7 @@ import { DataQuery } from '@grafana/schema';
 /**
  * Query used with Cribl Search.  Can either use a saved search or run an adhoc query.
  */
-export type CriblQuery = DataQuery & {
-  /**
-   * Max number of results to fetch
-   */
-  maxResults: number;
-} & (
+export type CriblQuery = DataQuery & (
   {
     type: 'adhoc';
     /**


### PR DESCRIPTION
Here's a demo of how it used to look/behave:

https://github.com/criblio/cribl-search-grafana-plugin/assets/281311/374f426a-70c2-4dc5-b016-14e4523e3ea6

Here's a link to some discussion about this on Slack:

https://cribl.slack.com/archives/C072A93UXGR/p1715698015726779

Now it behaves more like our own UI, imposing the 10k fixed limit.