### PR TITLE
SEARCH-6138 Auto-prepend "cribl" operator (best effort)

### DIFF
--- a/src/datasource.test.ts
+++ b/src/datasource.test.ts
@@ -60,7 +60,7 @@ describe('datasource', () => {
         expected: 'let stage1 = foo; let stage2 = cribl bar; set baz="biff"; cribl dataset="$vt_dummy" event < 10',
       },
     ].forEach(({ query, expected }) => {
-      it(`should work prepend cribl as needed: ${query}`, () => {
+      it(`should prepend cribl as needed: ${query}`, () => {
         expect(prependCriblOperator(query)).toBe(expected);
       });
     });

--- a/src/datasource.test.ts
+++ b/src/datasource.test.ts
@@ -1,0 +1,68 @@
+import { prependCriblOperator } from "datasource";
+
+describe('datasource', () => {
+  describe('prependCriblOperator', () => {
+    [
+      {
+        query: 'print 42',
+        expected: 'print 42',
+      },
+      {
+        query: 'search in(foo) * | where bar="hello"',
+        expected: 'search in(foo) * | where bar="hello"',
+      },
+      {
+        query: 'find in(foo) * | where bar="hello"',
+        expected: 'find in(foo) * | where bar="hello"',
+      },
+      {
+        query: 'externaldata ["blah"] | summarize by foo',
+        expected: 'externaldata ["blah"] | summarize by foo',
+      },
+      {
+        query: 'needle',
+        expected: 'cribl needle',
+      },
+      {
+        query: '"needle"',
+        expected: 'cribl "needle"',
+      },
+      {
+        query: '* | where foo=42',
+        expected: 'cribl * | where foo=42',
+      },
+      {
+        query: 'dataset="$vt_dummy" event < 10',
+        expected: 'cribl dataset="$vt_dummy" event < 10',
+      },
+      {
+        query: 'cribl dataset="$vt_dummy" event < 10',
+        expected: 'cribl dataset="$vt_dummy" event < 10',
+      },
+      {
+        query: 'set logger_level="debug"; dataset="$vt_dummy" event < 10',
+        expected: 'set logger_level="debug"; cribl dataset="$vt_dummy" event < 10',
+      },
+      {
+        query: 'set logger_level="debug"; cribl dataset="$vt_dummy" event < 10',
+        expected: 'set logger_level="debug"; cribl dataset="$vt_dummy" event < 10',
+      },
+      {
+        query: 'set logger_level="debug"; set foo=42; dataset="$vt_dummy" event < 10',
+        expected: 'set logger_level="debug"; set foo=42; cribl dataset="$vt_dummy" event < 10',
+      },
+      {
+        query: 'let stage1 = foo; let stage2 = bar; set baz="biff"; dataset="$vt_dummy" event < 10',
+        expected: 'let stage1 = foo; let stage2 = bar; set baz="biff"; cribl dataset="$vt_dummy" event < 10',
+      },
+      {
+        query: 'let stage1 = foo; let stage2 = cribl bar; set baz="biff"; dataset="$vt_dummy" event < 10',
+        expected: 'let stage1 = foo; let stage2 = cribl bar; set baz="biff"; cribl dataset="$vt_dummy" event < 10',
+      },
+    ].forEach(({ query, expected }) => {
+      it(`should work prepend cribl as needed: ${query}`, () => {
+        expect(prependCriblOperator(query)).toBe(expected);
+      });
+    });
+  });
+});

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -352,9 +352,26 @@ function parseJwtExp(token: string): number {
   return JSON.parse(jsonPayload).exp;
 }
 
-function prependCriblOperator(query: string): string {
-  if (query.trim().startsWith('print')) {
-    return query;
+/**
+ * Cribl Search backend requires a fully-formed query including the "cribl" operator.
+ * Here we're applying best effort to auto-prepending the "cribl" operator where it needs to be.
+ * This is far from 100% foolproof, but covers 99% of the happy paths.
+ * @param query the query as the user entered it
+ * @returns the query with "cribl" operator prepended as needed, if we were able to
+ */
+export function prependCriblOperator(query: string): string {
+  // This tries to capture the first "word" of the root query statement, along with any preceding
+  // "set" or "let" statements, and everything that comes after the first word.  NOTE: This doesn't
+  // touch any "let" statements.  We might enhance that in the future, but for now, users need to
+  // put their own "cribl" operator in those stage statements.
+  const firstWordRegex = /^((?:\s*(?:set|let)\s+[^;]+;)*\s*)((\w+|['"*]).*)$/;
+  const matches = query.trim().match(firstWordRegex);
+  if (matches != null) {
+    const firstWord = matches[3];
+    // We recognize certain operators that don't need "cribl" prepended
+    if (!['cribl', 'externaldata', 'find', 'print', 'search'].includes(firstWord)) {
+      return `${matches[1]}cribl ${matches[2]}`;
+    }
   }
-  return `cribl ${query}`; // TODO: make this not dumb
+  return query;
 }

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -1,6 +1,6 @@
-import { prependCriblOperator } from "datasource";
+import { prependCriblOperator } from "utils";
 
-describe('datasource', () => {
+describe('utils', () => {
   describe('prependCriblOperator', () => {
     [
       {
@@ -58,6 +58,15 @@ describe('datasource', () => {
       {
         query: 'let stage1 = foo; let stage2 = cribl bar; set baz="biff"; dataset="$vt_dummy" event < 10',
         expected: 'let stage1 = foo; let stage2 = cribl bar; set baz="biff"; cribl dataset="$vt_dummy" event < 10',
+      },
+      // These should never be run in this context, but at least we don't prepend cribl
+      {
+        query: '.show all queries',
+        expected: '.show all queries',
+      },
+      {
+        query: '.show objects(cribl_search_sample)',
+        expected: '.show objects(cribl_search_sample)',
       },
     ].forEach(({ query, expected }) => {
       it(`should prepend cribl as needed: ${query}`, () => {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,23 @@
+/**
+ * Cribl Search backend requires a fully-formed query including the "cribl" operator.
+ * Here we're applying best effort to auto-prepending the "cribl" operator where it needs to be.
+ * This is far from 100% foolproof, but covers 99% of the happy paths.
+ * @param query the query as the user entered it
+ * @returns the query with "cribl" operator prepended as needed, if we were able to
+ */
+export function prependCriblOperator(query: string): string {
+  // This tries to capture the first "word" of the root query statement, along with any preceding
+  // "set" or "let" statements, and everything that comes after the first word.  NOTE: This doesn't
+  // touch any "let" statements.  We might enhance that in the future, but for now, users need to
+  // put their own "cribl" operator in those stage statements.
+  const firstWordRegex = /^((?:\s*(?:set|let)\s+[^;]+;)*\s*)((\w+|['"*]).*)$/;
+  const matches = query.trim().match(firstWordRegex);
+  if (matches != null) {
+    const firstWord = matches[3];
+    // We recognize certain operators that don't need "cribl" prepended
+    if (!['cribl', 'externaldata', 'find', 'print', 'search'].includes(firstWord)) {
+      return `${matches[1]}cribl ${matches[2]}`;
+    }
+  }
+  return query;
+}


### PR DESCRIPTION
This isn't perfect, but as you can see in the unit test, it's pretty good.  Should be all we need to get this launched and going, while giving users the convenience of not needing to explicitly put `cribl` in their queries.