### PR TITLE
SEARCH-6235 "Saved Search" is reset if an existing panel is edited

### DIFF
--- a/src/components/QueryEditor.tsx
+++ b/src/components/QueryEditor.tsx
@@ -15,7 +15,7 @@ const DEBOUNCE_RUN_DELAY_MS = 750;
 export function QueryEditor({ datasource, query, onChange, onRunQuery }: Props) {
   const debouncedOnRunQuery = useRef(debounce(onRunQuery, DEBOUNCE_RUN_DELAY_MS)).current;
   const [savedSearchIdOptions, setSavedSearchIdOptions] = useState<SelectableValue[]>([]);
-  const [savedSearchId, setSavedSearchId] = useState('');
+  const [savedSearchId, setSavedSearchId] = useState(query.type === 'saved' ? query.savedSearchId : '');
 
   const [queryType, setQueryType] = useState<QueryType>(query.type ?? DEFAULT_QUERY_TYPE);
   const [adhocQuery, setAdhocQuery] = useState(query.type === 'adhoc' ? query.query : '');


### PR DESCRIPTION
This was just me being a React noob, not initializing the state to the known value when it was already set.  Bingo!