### PR TITLE
A few more required changes from Grafana Labs review

### DIFF
--- a/src/components/QueryEditor.tsx
+++ b/src/components/QueryEditor.tsx
@@ -13,11 +13,13 @@ const DEFAULT_QUERY_TYPE = 'adhoc';
 const DEBOUNCE_RUN_DELAY_MS = 750;
 
 export function QueryEditor({ datasource, query, onChange, onRunQuery }: Props) {
+  query.type = query.type ?? DEFAULT_QUERY_TYPE;
+
   const debouncedOnRunQuery = useRef(debounce(onRunQuery, DEBOUNCE_RUN_DELAY_MS)).current;
   const [savedSearchIdOptions, setSavedSearchIdOptions] = useState<SelectableValue[]>([]);
   const [savedSearchId, setSavedSearchId] = useState(query.type === 'saved' ? query.savedSearchId : '');
 
-  const [queryType, setQueryType] = useState<QueryType>(query.type ?? DEFAULT_QUERY_TYPE);
+  const [queryType, setQueryType] = useState<QueryType>(query.type);
   const [adhocQuery, setAdhocQuery] = useState(query.type === 'adhoc' ? query.query : '');
 
   const onQueryTypeChange = useCallback((sv: SelectableValue<string>) => {

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -66,6 +66,13 @@ export class CriblDataSource extends DataSourceApi<CriblQuery, CriblDataSourceOp
    * @returns the DataFrame with the results
    */
   private async processQuery(criblQuery: CriblQuery, range: TimeRange): Promise<DataFrame> {
+    if (!this.canRunQuery(criblQuery)) {
+      return {
+        fields: [],
+        length: 0,
+      };
+    }
+
     let fields: Record<string, Field> = {};
     let eventCount = 0;
     let totalEventCount: number | undefined = undefined;

--- a/src/plugin.json
+++ b/src/plugin.json
@@ -9,7 +9,7 @@
     "author": {
       "name": "Cribl, Inc."
     },
-    "keywords": ["datasource", "cribl", "search", "query", "data", "engine", "it", "security", "observability", "goat", "fafo", "deits"],
+    "keywords": ["datasource", "cribl", "search", "query", "data", "engine", "it", "security", "observability"],
     "logos": {
       "small": "img/cribl_logo.svg",
       "large": "img/cribl_logo.svg"


### PR DESCRIPTION
1. Remove #irreverent-but-serious keywords.
2. Graceful handling/defaulting when adding a new dashboard panel.
3. The fix for #2 is also a compatibility workaround for versions prior to 11.0.0, in which `filterQuery()` doesn't get invoked.  Still sticking with 10.3.3 as the minimum version we support.