### PR TITLE
SEARCH-8309 Allow savedSearchId to be composed using variable(s)

### DIFF
--- a/src/components/QueryEditor.tsx
+++ b/src/components/QueryEditor.tsx
@@ -48,7 +48,9 @@ export function QueryEditor({ datasource, query, onChange, onRunQuery }: Props) 
   const onSavedQueryIdChange = useCallback((sv: SelectableValue<string>) => {
     const newSavedSearchId = sv.value?.replace(/\s+/g, '') ?? ''; // auto-trim/remove any whitespace
     setSavedSearchId(newSavedSearchId);
-    if (newSavedSearchId !== savedSearchId && newSavedSearchId.match(/^[a-zA-Z0-9_]+$/)) {
+    // May contain ${...} style variables from the dashboard, but otherwise may contain only valid ID characters.
+    // May contain any combination of valid ID chars and dashboard variable(s).
+    if (newSavedSearchId !== savedSearchId && newSavedSearchId.match(/^([a-zA-Z0-9_]+|\$\{.+?\})+$/)) {
       onChange({ ...query, type: 'saved', savedSearchId: newSavedSearchId });
       debouncedOnRunQuery();
     }
@@ -74,7 +76,12 @@ export function QueryEditor({ datasource, query, onChange, onRunQuery }: Props) 
     if (queryType === 'saved') {
       return (
         <InlineField label="Saved Search" labelWidth={16} tooltip="ID of the Cribl saved search">
-          <Select onChange={onSavedQueryIdChange} options={savedSearchIdOptions} value={savedSearchId} width={24} />
+          <Select
+            allowCustomValue
+            onChange={onSavedQueryIdChange}
+            options={savedSearchIdOptions}
+            value={savedSearchIdOptions.find((o) => o.value === savedSearchId) || { label: savedSearchId, value: savedSearchId }}
+            width={24} />
         </InlineField>
       );
     } else {

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -12,13 +12,22 @@ export class CriblDataSource extends DataSourceWithBackend<CriblQuery, CriblData
   }
 
   applyTemplateVariables(criblQuery: CriblQuery, scopedVars: ScopedVars) {
-    if (criblQuery.type !== 'adhoc') {
-      return criblQuery;
+    switch (criblQuery.type) {
+      case 'adhoc':
+        return {
+          ...criblQuery,
+          // You can use dashboard variables in your query
+          query: getTemplateSrv().replace(criblQuery.query, scopedVars),
+        };
+      case 'saved':
+        return {
+          ...criblQuery,
+          // The savedSearchId can also be composed using dashboard variable(s)
+          savedSearchId: getTemplateSrv().replace(criblQuery.savedSearchId, scopedVars),
+        };
+      default: // exhaustive check
+        throw new Error(`Unexpected query type`);
     }
-    return {
-      ...criblQuery,
-      query: getTemplateSrv().replace(criblQuery.query, scopedVars),
-    };
   }
 
   filterQuery(query: CriblQuery): boolean {


### PR DESCRIPTION
We've gotten requests for users to be able to compose saved search IDs using dashboard variables.  Easy peasy.

Now you can type in your own saved search ID, and you can use `${variable}` style dashboard variable(s) as needed.