### PR TITLE
SEARCH-8100 Make query timeout configurable

### DIFF
--- a/pkg/models/settings.go
+++ b/pkg/models/settings.go
@@ -10,6 +10,7 @@ import (
 type PluginSettings struct {
 	CriblOrgBaseUrl string                `json:"criblOrgBaseUrl"`
 	ClientId        string                `json:"clientId"`
+	QueryTimeoutSec *float64              `json:"queryTimeoutSec"`
 	Secrets         *SecretPluginSettings `json:"-"`
 }
 

--- a/pkg/plugin/datasource.go
+++ b/pkg/plugin/datasource.go
@@ -28,7 +28,6 @@ var (
 const MAX_RESULTS = 10000 // same as what the actual Cribl UI imposes
 const QUERY_PAGE_SIZE = 1000
 const CRIBL_TIME_FIELD = "_time"
-const MAX_DELAY_WAITING_FOR_FINISHED = 60 * time.Second // could make this configurable in a future release
 const MAX_BACKOFF_DURATION = 2 * time.Second
 const GRAFANA_TIME_FIELD_NAME = "Time"
 
@@ -133,6 +132,11 @@ func (d *Datasource) query(_ context.Context, _ backend.PluginContext, dataQuery
 
 	eventCount := 0
 	totalEventCount := -1
+	maxQueryDuration := time.Duration(0)
+	if d.Settings.QueryTimeoutSec != nil {
+		maxQueryDuration = time.Duration(*d.Settings.QueryTimeoutSec * 1e9)
+	}
+	backend.Logger.Info("timeout will be", "maxQueryDuration", maxQueryDuration, "queryTimeoutSec", d.Settings.QueryTimeoutSec)
 	startTime := time.Now()
 
 	// Load the search results, paging through until we've hit MAX_RESULTS or read all events, whatever comes first
@@ -173,8 +177,10 @@ func (d *Datasource) query(_ context.Context, _ backend.PluginContext, dataQuery
 		// new job, and we get isFinished=false.  When this is the case, grab the job ID and poll until the job is finished.
 		if !result.Header["isFinished"].(bool) {
 			elapsed := time.Since(startTime)
-			if elapsed >= MAX_DELAY_WAITING_FOR_FINISHED {
-				return backend.ErrDataResponse(backend.StatusBadRequest, fmt.Sprintf("Job %s still not finished after %v (status=%v)", jobId, elapsed, status))
+			// If there's a configured timeout, ensure we don't let the query run longer than that
+			if maxQueryDuration > 0 && elapsed >= maxQueryDuration {
+				// TODO: cancel the query
+				return backend.ErrDataResponse(backend.StatusBadRequest, fmt.Sprintf("Job %s still not finished after %v (status=%v)", jobId, maxQueryDuration, status))
 			}
 			a, b = b, a+b // Fibonacci backoff
 			backoffDuration := a

--- a/src/types.ts
+++ b/src/types.ts
@@ -45,6 +45,10 @@ export interface CriblDataSourceOptions extends DataSourceJsonData {
    * Client ID used to generate OAuth tokens
    */
   clientId?: string;
+  /**
+   * How long we're willing to wait for a query to run before giving up on it.
+   */
+  queryTimeoutSec?: number;
 }
 
 /**


### PR DESCRIPTION
This moves away from the hardcoded 60-second timeout and enables the timeout to be configured on the dataset.

It can be left blank to mean no timeout, which can be useful if for some reason you really want long-running searches in your Grafana dashboard panels.  But hey, you do you.

<img width="756" alt="Screenshot 2024-12-08 at 6 00 59 PM" src="https://github.com/user-attachments/assets/a59c5351-3de8-4f57-835c-145fd943c29c">

And users for whom 60 seconds was too restrictive can now tweak it to something more appropriate for their needs.

<img width="807" alt="Screenshot 2024-12-08 at 6 00 50 PM" src="https://github.com/user-attachments/assets/4e470029-2a94-4ca4-8a8b-b21c292a8ca0">

There's some basic validation in the UI, allowing only a positive integer value.

<img width="746" alt="Screenshot 2024-12-08 at 6 01 23 PM" src="https://github.com/user-attachments/assets/726d4925-148b-4696-b08f-6f6b9e903f23">

And just as before, you get an error message if the query takes longer than the configured timeout.

<img width="1263" alt="Screenshot 2024-12-08 at 6 06 37 PM" src="https://github.com/user-attachments/assets/53821127-10b5-42de-833f-5433c82c3ae6">

## Future Work

We'll be following up soon with an enhancement that will cancel the query when the timeout kicks in (instead of leaving it running).