### PR TITLE
SEARCH-8103 Include info about scheduled searches in the timeout error

### DIFF
--- a/pkg/plugin/datasource.go
+++ b/pkg/plugin/datasource.go
@@ -180,7 +180,7 @@ func (d *Datasource) query(_ context.Context, _ backend.PluginContext, dataQuery
 			// If there's a configured timeout, ensure we don't let the query run longer than that
 			if maxQueryDuration > 0 && elapsed >= maxQueryDuration {
 				// TODO: cancel the query
-				return backend.ErrDataResponse(backend.StatusBadRequest, fmt.Sprintf("Job %s still not finished after %v (status=%v)", jobId, maxQueryDuration, status))
+				return backend.ErrDataResponse(backend.StatusBadRequest, fmt.Sprintf("Job %s still not finished after %v (status=%v). Consider using a scheduled search to speed this up. https://docs.cribl.io/search/scheduled-searches/", jobId, maxQueryDuration, status))
 			}
 			a, b = b, a+b // Fibonacci backoff
 			backoffDuration := a


### PR DESCRIPTION
Simple change that hopefully helps the user learn how to speed things up.
<img width="1213" alt="Screenshot 2024-12-08 at 6 25 56 PM" src="https://github.com/user-attachments/assets/e9fbc2e6-d372-4b88-a7fc-587156be0c6d">
