### PR TITLE
SEARCH-8101 Cancel the query upon timeout

### DIFF
--- a/pkg/plugin/datasource.go
+++ b/pkg/plugin/datasource.go
@@ -179,7 +179,11 @@ func (d *Datasource) query(_ context.Context, _ backend.PluginContext, dataQuery
 			elapsed := time.Since(startTime)
 			// If there's a configured timeout, ensure we don't let the query run longer than that
 			if maxQueryDuration > 0 && elapsed >= maxQueryDuration {
-				// TODO: cancel the query
+				backend.Logger.Debug("query timed out, canceling", "jobId", jobId)
+				err := d.SearchAPI.CancelQuery(jobId)
+				if err != nil {
+					backend.Logger.Warn("failed to cancel query", "jobId", jobId, "err", err)
+				}
 				return backend.ErrDataResponse(backend.StatusBadRequest, fmt.Sprintf("Job %s still not finished after %v (status=%v). Consider using a scheduled search to speed this up. https://docs.cribl.io/search/scheduled-searches/", jobId, maxQueryDuration, status))
 			}
 			a, b = b, a+b // Fibonacci backoff


### PR DESCRIPTION
If the query takes longer than the configured timeout, at least try to cancel the search job on the Cribl side.

To test this, you can set the timeout to a relatively low value like 5 or 10 seconds, then run a query like
```
dataset="$vt_dummy" second < 420
```

On the Cribl side, you can find the job by its id and confirm that it was indeed canceled.