### PR TITLE
SEARCH-8423 Fix time field type

### DIFF
--- a/pkg/plugin/datasource.go
+++ b/pkg/plugin/datasource.go
@@ -208,13 +208,13 @@ func (d *Datasource) query(_ context.Context, _ backend.PluginContext, dataQuery
 			// Grab the keys and values from the event and populate fields in the frame
 			for fieldName, value := range event {
 				if fieldName == CRIBL_TIME_FIELD {
-					// _time is in seconds, and Grafana needs it in ISO format.  If the conversion is successful
-					// (which it will be most of the time), we use Grafana's well-known "time" field name instead.
-					// If the conversion fails, _time is something other than seconds, and it will pass-through
-					// as is with the "_time" field name.
-					if ok, isoString := timeToIsoString(value); ok {
+					// Two things are happening here:
+					// 1. Instead of our "_time" we use Grafana's well-known "time" field name.
+					// 2. Convert from seconds to time.Time struct.  If the conversion fails, _time must be something
+					// other than seconds, and it will pass-through as is with the original "_time" field name.
+					if ok, time := criblTimeToGrafanaTime(value); ok {
 						fieldName = GRAFANA_TIME_FIELD_NAME
-						value = isoString
+						value = time
 					}
 				}
 

--- a/pkg/plugin/utils_test.go
+++ b/pkg/plugin/utils_test.go
@@ -63,42 +63,46 @@ func TestCollapseToSingleLine(t *testing.T) {
 	assert.Equal(t, `hello there aw yeah`, collapseToSingleLine("hello\nthere\taw\r\nyeah"))
 }
 
-func TestTimeToIsoString(t *testing.T) {
+func TestCriblTimeToGrafanaTime(t *testing.T) {
 	for _, test := range []struct {
 		In       interface{}
-		Expected string
+		Expected int64
 	}{
 		{
 			In:       nil,
-			Expected: "",
+			Expected: 0,
 		},
 		{
 			In:       false,
-			Expected: "",
+			Expected: 0,
 		},
 		{
 			In:       true,
-			Expected: "",
+			Expected: 0,
 		},
 		{
 			In:       "whatever",
-			Expected: "",
+			Expected: 0,
 		},
 		{
 			In:       float64(1728744793),
-			Expected: "2024-10-12T14:53:13Z",
+			Expected: 1728744793000000,
 		},
 		{
 			In:       float64(1728744793.123),
-			Expected: "2024-10-12T14:53:13.123Z",
+			Expected: 1728744793123000,
+		},
+		{
+			In:       float64(1728744793.123456),
+			Expected: 1728744793123456,
 		},
 	} {
-		ok, out := timeToIsoString(test.In)
-		if len(test.Expected) == 0 {
+		ok, out := criblTimeToGrafanaTime(test.In)
+		if test.Expected == 0 {
 			assert.Equal(t, false, ok, fmt.Sprintf("input %v produced ok=%v, out=%v", test.In, ok, out))
 		} else {
 			assert.Equal(t, true, ok, fmt.Sprintf("input %v produced ok=%v, out=%v", test.In, ok, out))
-			assert.Equal(t, test.Expected, out, test.In)
+			assert.Equal(t, test.Expected, out.UnixMicro(), test.In)
 		}
 	}
 }


### PR DESCRIPTION
## What Was Wrong

Grafana was saying `Data is missing a time field` and wouldn't let you graph the data as a time series (or anything related to time).  It was confusing, since clearly there's a Time field with valid timestamps.

We were passing back the `time` field as an ISO string...which was more or less fine, but we were inadvertently setting the field type to `string` -- implicitly because of the value's native type.  Apparently the name `time` alone and the ISO format wasn't enough for Grafana to recognize it.

And the real problem is: Grafana's Go `data` library doesn't let you explicitly set the `type` on a field.  This is kinda crummy API design, but they're trying to make it easy -- just set the value and the data layer figures out what it is.  But when we pass a string, it thinks the type is `string`.

## What's Changing

Use the `time.Time` struct so Grafana's `data` layer knows that it's actually time.

## To Verify

Run a query that produces `timestats` (or anything with time, really) and try to add it to a dashboard as a Time Series visualization.